### PR TITLE
Parameterize dhall-json for building on Darwin

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@ let easy-dhall-nix = pkgs: import (pkgs.fetchFromGitHub {
 }; in
 
 { pkgs ? import <nixpkgs> {}
-, dhallJson ? (easy-dhall-nix pkgs).dhall-json-simple
+, dhall-json ? (easy-dhall-nix pkgs).dhall-json-simple
 }:
 
 let easy-purescript-nix = import (pkgs.fetchFromGitHub {
@@ -39,7 +39,7 @@ pkgs.stdenv.mkDerivation {
         pkgs.nix-prefetch-git
         easy-purescript-nix.purs
         easy-purescript-nix.spago
-        dhallJson
+        dhall-json
       ]}
   '';
 }

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@ let easy-dhall-nix = pkgs: import (pkgs.fetchFromGitHub {
 }; in
 
 { pkgs ? import <nixpkgs> {}
-, dhall-json ? (easy-dhall-nix pkgs).dhall-json-simple
+, dhallJson ? (easy-dhall-nix pkgs).dhall-json-simple
 }:
 
 let easy-purescript-nix = import (pkgs.fetchFromGitHub {
@@ -39,7 +39,7 @@ pkgs.stdenv.mkDerivation {
         pkgs.nix-prefetch-git
         easy-purescript-nix.purs
         easy-purescript-nix.spago
-        dhall-json
+        dhallJson
       ]}
   '';
 }

--- a/default.nix
+++ b/default.nix
@@ -1,23 +1,24 @@
-{ pkgs ? import <nixpkgs> {} }:
+let easy-dhall-nix = pkgs: import (pkgs.fetchFromGitHub {
+  owner = "justinwoo";
+  repo = "easy-dhall-nix";
+  rev = "b4736f4496cf313d41203f75a87f229b9a435f76";
+  sha256 = "0lzzbwnkfs5fqya0r2wzzrysmn08rl002cndkz9s261gydp03pz4";
+}) {
+  inherit pkgs;
+}; in
 
-let
-  easy-dhall-nix = import (pkgs.fetchFromGitHub {
-    owner = "justinwoo";
-    repo = "easy-dhall-nix";
-    rev = "b4736f4496cf313d41203f75a87f229b9a435f76";
-    sha256 = "0lzzbwnkfs5fqya0r2wzzrysmn08rl002cndkz9s261gydp03pz4";
-  }) {
-    inherit pkgs;
-  };
+{ pkgs ? import <nixpkgs> {}
+, dhall-json ? (easy-dhall-nix pkgs).dhall-json-simple
+}:
 
-  easy-purescript-nix = import (pkgs.fetchFromGitHub {
-    owner = "justinwoo";
-    repo = "easy-purescript-nix";
-    rev = "3cc22df4d4495b884d4537c715316fd83dfe4831";
-    sha256 = "1h5cfligvgnbbhq98vmzsvb7b37gmvsk17k7qxncfb66l3jshcmp";
-  });
+let easy-purescript-nix = import (pkgs.fetchFromGitHub {
+  owner = "justinwoo";
+  repo = "easy-purescript-nix";
+  rev = "3cc22df4d4495b884d4537c715316fd83dfe4831";
+  sha256 = "1h5cfligvgnbbhq98vmzsvb7b37gmvsk17k7qxncfb66l3jshcmp";
+}); in
 
-in pkgs.stdenv.mkDerivation {
+pkgs.stdenv.mkDerivation {
   name = "spago2nix";
 
   src = ./.;
@@ -38,7 +39,7 @@ in pkgs.stdenv.mkDerivation {
         pkgs.nix-prefetch-git
         easy-purescript-nix.purs
         easy-purescript-nix.spago
-        easy-dhall-nix.dhall-json-simple
+        dhall-json
       ]}
   '';
 }


### PR DESCRIPTION
This allows users on platforms other than Linux to provide their own `dhall-json` since `easy-dhall-nix` is hardcoded to use Linux binaries.

```nix
let spago2nix = import ./nix/pkgs/spago2nix.nix {
  inherit pkgs;
  inherit (pkgs) dhall-json;
}; in
```

This is a backwards compatible change. If the `dhall-json` attribute is omitted, `easy-dhall-nix.dhall-json-simple` is used as it was before.