### PR TITLE
Adding coreutils to path wrapper for GNU-specific cp options used in spago2nix install

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -41,6 +41,7 @@ in pkgs.stdenv.mkDerivation {
 
     wrapProgram $target \
       --prefix PATH : ${pkgs.lib.makeBinPath [
+        pkgs.coreutils
         pkgs.nix-prefetch-git
         easy-purescript-nix.spago
         dhall-json


### PR DESCRIPTION
Another macos fix. Would probably work for the unicorns out there using nix and purescript on *bsd too.