### PR TITLE
Update Example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pkgs.stdenv.mkDerivation rec {
   buildPhase = 
   '' 
     ${spagoPkgs.installSpagoStyle} # == spago2nix install
-    ${spagoPkgs.buildSpagoStyle}   # == spago2nix build
+    ${spagoPkgs.buildSpagoStyle} src/Main.purs  # == spago2nix build
   '';
   # < ... >
 }


### PR DESCRIPTION
To me it looks like `spago2nix build` builds your own source plus libraries. And `${spagoPkgs.buildSpagoStyle} ` builds only your libraries if not given an entry point. But correct me if I miss something here.