### PR TITLE
Refactor and Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,15 @@ let
 in
 pkgs.stdenv.mkDerivation rec {
   # < ... >
+  src = ./.;
+
+  buildInputs = [ spagoPackages.installSpagoStyle ];
+
   buildPhase = 
   '' 
-    ${spagoPkgs.installSpagoStyle} # == spago2nix install
-    ${spagoPkgs.buildSpagoStyle}   # == spago2nix build
+    installSpagoStyle # == spago2nix install
+
+    ${spagoPackages.mkBuildProjectOutput { inherit src purescript; }}
   '';
   # < ... >
 }

--- a/src/Generate.purs
+++ b/src/Generate.purs
@@ -154,20 +154,20 @@ in {
   '';
 
   buildSpagoStyle = pkgs.writeShellScriptBin "build-spago-style" ''
-    EXTRA_FILES=$@
+    EXTRA_FILES="$@"
 
     echo "echo building project..."
     echo "purs compile ${builtins.toString (
-      builtins.map getGlob (builtins.attrValues inputs))}" \"\$EXTRA_FILES\"
+      builtins.map getGlob (builtins.attrValues inputs))}" \$EXTRA_FILES
     echo "echo done."
   '';
 
   buildFromNixStore = pkgs.writeShellScriptBin "build-from-store" ''
-    EXTRA_FILES=$@
+    EXTRA_FILES="$@"
 
     echo "echo building project using sources from nix store..."
     echo "purs compile ${builtins.toString (
-      builtins.map getStoreGlob (builtins.attrValues inputs))}" \"\$EXTRA_FILES\"
+      builtins.map getStoreGlob (builtins.attrValues inputs))}" \$EXTRA_FILES
     echo "echo done."
   '';
 

--- a/src/Generate.purs
+++ b/src/Generate.purs
@@ -172,13 +172,13 @@ in {
   '';
 
   mkBuildProjectOutput =
-    { src, purs }:
+    { src, purescript }:
 
     pkgs.stdenv.mkDerivation {
       name = "build-project-output";
       src = src;
 
-      buildInputs = [ purs ];
+      buildInputs = [ purescript ];
 
       installPhase = ''
         mkdir -p $out

--- a/src/Generate.purs
+++ b/src/Generate.purs
@@ -146,34 +146,29 @@ INPUTS
 in {
   inherit inputs;
 
-  installSpagoStyle = pkgs.runCommand "install-spago-style" {} ''
-      >>$out echo "#!/usr/bin/env bash"
-      >>$out echo
-      >>$out echo "echo installing dependencies..."
-      >>$out echo "${builtins.toString (
-        builtins.map cpPackage (builtins.attrValues inputs))}"
-      >>$out echo "echo done."
-      chmod +x $out
+  installSpagoStyle = pkgs.writeShellScriptBin "install-spago-style" ''
+    echo "installing dependencies..."
+    ${builtins.toString (
+       builtins.map cpPackage (builtins.attrValues inputs))}
+    echo "done."
   '';
 
-  buildSpagoStyle = pkgs.runCommand "build-spago-style" {} ''
-      >>$out echo "#!/usr/bin/env bash"
-      >>$out echo
-      >>$out echo "echo building project..."
-      >>$out echo "purs compile ${builtins.toString (
-        builtins.map getGlob (builtins.attrValues inputs))}" \"\$@\"
-      >>$out echo "echo done."
-      chmod +x $out
+  buildSpagoStyle = pkgs.writeShellScriptBin "build-spago-style" ''
+    EXTRA_FILES=$@
+
+    echo "echo building project..."
+    echo "purs compile ${builtins.toString (
+      builtins.map getGlob (builtins.attrValues inputs))}" \"\$EXTRA_FILES\"
+    echo "echo done."
   '';
 
-  buildFromNixStore = pkgs.runCommand "build-from-store" {} ''
-      >>$out echo "#!/usr/bin/env bash"
-      >>$out echo
-      >>$out echo "echo building project using sources from nix store..."
-      >>$out echo "purs compile ${builtins.toString (
-        builtins.map getStoreGlob (builtins.attrValues inputs))}" \"\$@\"
-      >>$out echo "echo done."
-      chmod +x $out
+  buildFromNixStore = pkgs.writeShellScriptBin "build-from-store" ''
+    EXTRA_FILES=$@
+
+    echo "echo building project using sources from nix store..."
+    echo "purs compile ${builtins.toString (
+      builtins.map getStoreGlob (builtins.attrValues inputs))}" \"\$EXTRA_FILES\"
+    echo "echo done."
   '';
 
   mkBuildProjectOutput =


### PR DESCRIPTION
This PR enhances the README example to use the newly created `mkBuildProjectOutput` function.
It contains also some refactoring on the other build functions in the generated file.