### PR TITLE
Allow specifying alternative version of `spago`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,25 +10,24 @@ let
     inherit pkgs;
   };
 
+  easy-purescript-nix = pkgs: import (
+    pkgs.fetchFromGitHub {
+      owner = "justinwoo";
+      repo = "easy-purescript-nix";
+      rev = "1ec689df0adf8e8ada7fcfcb513876307ea34226";
+      sha256 = "12hk2zbjkrq2i5fs6xb3x254lnhm9fzkcxph0a7ngxyzfykvf4hi";
+    }
+  ) {
+    inherit pkgs;
+  };
+
 in
 { pkgs ? import <nixpkgs> {}
 , dhall-json ? (easy-dhall-nix pkgs).dhall-json-simple
 , nodejs ? pkgs.nodejs-10_x
+, spago ? (easy-purescript-nix pkgs).spago
 }:
 
-  let
-    easy-purescript-nix = import (
-      pkgs.fetchFromGitHub {
-        owner = "justinwoo";
-        repo = "easy-purescript-nix";
-        rev = "1ec689df0adf8e8ada7fcfcb513876307ea34226";
-        sha256 = "12hk2zbjkrq2i5fs6xb3x254lnhm9fzkcxph0a7ngxyzfykvf4hi";
-      }
-    ) {
-      inherit pkgs;
-    };
-
-  in
     pkgs.stdenv.mkDerivation {
       name = "spago2nix";
 
@@ -49,7 +48,7 @@ in
           --prefix PATH : ${pkgs.lib.makeBinPath [
         pkgs.coreutils
         pkgs.nix-prefetch-git
-        easy-purescript-nix.spago
+        spago
         dhall-json
       ]}
       '';

--- a/default.nix
+++ b/default.nix
@@ -14,8 +14,8 @@ let
     pkgs.fetchFromGitHub {
       owner = "justinwoo";
       repo = "easy-purescript-nix";
-      rev = "1ec689df0adf8e8ada7fcfcb513876307ea34226";
-      sha256 = "12hk2zbjkrq2i5fs6xb3x254lnhm9fzkcxph0a7ngxyzfykvf4hi";
+      rev = "e8a1ffafafcdf2e81adba419693eb35f3ee422f8";
+      sha256 = "0bk32wckk82f1j5i5gva63f3b3jl8swc941c33bqc3pfg5cgkyyf";
     }
   ) {
     inherit pkgs;

--- a/default.nix
+++ b/default.nix
@@ -28,28 +28,28 @@ in
 , spago ? (easy-purescript-nix pkgs).spago
 }:
 
-    pkgs.stdenv.mkDerivation {
-      name = "spago2nix";
+pkgs.stdenv.mkDerivation {
+  name = "spago2nix";
 
-      src = pkgs.nix-gitignore.gitignoreSource [ ".git" ] ./.;
+  src = pkgs.nix-gitignore.gitignoreSource [ ".git" ] ./.;
 
-      buildInputs = [ pkgs.makeWrapper ];
+  buildInputs = [ pkgs.makeWrapper ];
 
-      installPhase = ''
-        mkdir -p $out/bin
-        target=$out/bin/spago2nix
+  installPhase = ''
+    mkdir -p $out/bin
+    target=$out/bin/spago2nix
 
-        >>$target echo '#!${nodejs}/bin/node'
-        >>$target echo "require('$src/bin/output.js')";
+    >>$target echo '#!${nodejs}/bin/node'
+    >>$target echo "require('$src/bin/output.js')";
 
-        chmod +x $target
+    chmod +x $target
 
-        wrapProgram $target \
-          --prefix PATH : ${pkgs.lib.makeBinPath [
-        pkgs.coreutils
-        pkgs.nix-prefetch-git
-        spago
-        dhall-json
-      ]}
-      '';
-    }
+    wrapProgram $target \
+      --prefix PATH : ${pkgs.lib.makeBinPath [
+    pkgs.coreutils
+    pkgs.nix-prefetch-git
+    spago
+    dhall-json
+  ]}
+  '';
+}


### PR DESCRIPTION
### Problem

I was getting the same error described in this issue: https://github.com/justinwoo/spago2nix/issues/29

The problem is `spago2nix` is using an older version of `spago` which uses `spago list-packages` and not the new `spago ls packages` form.

### Solution

I made it possible to customize the version of `spago` used, following the same format as your existing `dhall-json` setup.

I also updated the pinned `easy-purescript-nix` to the latest revision, which also happens to use a compatible version of `spago`.