### PR TITLE
Use stdenvNoCC in generated output

### DIFF
--- a/src/Generate.purs
+++ b/src/Generate.purs
@@ -173,7 +173,7 @@ in {
   mkBuildProjectOutput =
     { src, purs }:
 
-    pkgs.stdenv.mkDerivation {
+    pkgs.stdenvNoCC.mkDerivation {
       name = "build-project-output";
       src = src;
 
@@ -211,7 +211,7 @@ printResult (Fetched
   <<< replace { from: "REV", to: rev }
   <<< replace { from: "SHA256", to: sha256 }
     $ """
-    "PKGNAME" = pkgs.stdenv.mkDerivation {
+    "PKGNAME" = pkgs.stdenvNoCC.mkDerivation {
         name = "PKGNAME";
         version = "VERSION";
         src = pkgs.fetchgit {


### PR DESCRIPTION
This reduces the build closure substantially since it no longer pulls in the entire C build environment.

For example, using `build-project.nix`:

With `stdenv`:

    $ nix path-info --closure-size --human-readable $(nix-build --no-out-link -A inputDerivation build-project.nix)
    …
    /nix/store/v96sbzyinh0zfkk0c13i6dx3hkrlvds1-build-project-output	 322.5M

With `stdenvNoCC`:

    $ nix path-info --closure-size --human-readable $(nix-build --no-out-link -A inputDerivation build-project.nix)
    …
    /nix/store/9v3jldf3cnm204nw5w6szb8rvdxqhpsz-build-project-output	 108.0M